### PR TITLE
feat(pipeline): added preview environment stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
           branch 'feature-*'
         }
         environment {
+          HELM_RELEASE_NAME = "$BRANCH_NAME".toLowerCase()
           PREVIEW_NAMESPACE = "$BRANCH_NAME".toLowerCase()
           GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
           SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,12 +157,13 @@ pipeline {
       cleanWs()
     }
   }
-  def delete_deployment() {
-    container('maven') {
-      dir("./charts/$APP_NAME") {
-        sh "make delete"
-      }
-      sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
+}
+
+def delete_deployment() {
+  container('maven') {
+    dir("./charts/$APP_NAME") {
+      sh "make delete"
     }
+    sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,14 +44,16 @@ pipeline {
           input "Click Abort to delete preview environment: ${HELM_RELEASE_NAME}"
         }
       }
-      aborted {
-        container('maven') {
-          dir("./charts/$APP_NAME") {
-            sh "make delete"
-            sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
+      post{ 
+        aborted {
+          container('maven') {
+            dir("./charts/$APP_NAME") {
+              sh "make delete"
+              sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
+            }
           }
-        }          
-      }        
+        }
+      }
     }
     stage('CI Build and push snapshot') {
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,26 @@ pipeline {
 
     }
     stages {
+      stage('Create Preview Environment') {
+        when {
+          branch 'feature-*'
+        }
+        environment {
+          PREVIEW_NAMESPACE = "$BRANCH_NAME".toLowerCase()
+          GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+          SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+        }
+        steps {
+          container('maven') {
+          sh 'make validate'
+           dir ("./charts/$APP_NAME") {
+              sh 'make install'
+            }
+
+            input "Wait"
+          }
+        }
+      }
       stage('CI Build and push snapshot') {
         when {
           branch 'PR-*'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,150 +1,172 @@
 pipeline {
-    options {
-      disableConcurrentBuilds()
-    }  
-    agent {
-      label "jenkins-maven-java11"
-    }
-    environment {
-      ORG               = 'activiti'
-      APP_NAME          = 'activiti-cloud-full-example'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GITHUB_CHARTS_REPO    = "https://github.com/Activiti/activiti-cloud-helm-charts.git"
-      GITHUB_HELM_REPO_URL = "https://activiti.github.io/activiti-cloud-helm-charts/"
-      HELM_RELEASE_NAME = "example-$BRANCH_NAME-$BUILD_NUMBER".toLowerCase()
+  options {
+    disableConcurrentBuilds()
+  }  
+  agent {
+    label "jenkins-maven-java11"
+  }
+  environment {
+    ORG               = 'activiti'
+    APP_NAME          = 'activiti-cloud-full-example'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+    GITHUB_CHARTS_REPO    = "https://github.com/Activiti/activiti-cloud-helm-charts.git"
+    GITHUB_HELM_REPO_URL = "https://activiti.github.io/activiti-cloud-helm-charts/"
+    HELM_RELEASE_NAME = "example-$BRANCH_NAME-$BUILD_NUMBER".toLowerCase()
 
-      PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
-      PREVIEW_NAMESPACE = "example-$BRANCH_NAME-$BUILD_NUMBER".toLowerCase()
-      GLOBAL_GATEWAY_DOMAIN="35.228.195.195.nip.io"
-      REALM = "activiti"    
-      LOGGING_LEVEL_ORG_ACTIVITI_CLOUD_ACC_CORE_SERVICES = "INFO" 
+    PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+    PREVIEW_NAMESPACE = "example-$BRANCH_NAME-$BUILD_NUMBER".toLowerCase()
+    GLOBAL_GATEWAY_DOMAIN="35.228.195.195.nip.io"
+    REALM = "activiti"    
+    LOGGING_LEVEL_ORG_ACTIVITI_CLOUD_ACC_CORE_SERVICES = "INFO" 
+  }
+  stages {
+    stage('Create Preview Environment') {
+      when {
+        branch 'feature-*'
+      }
+      environment {
+        HELM_RELEASE_NAME = "$BRANCH_NAME".toLowerCase()
+        PREVIEW_NAMESPACE = "$BRANCH_NAME".toLowerCase()
+        GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+        SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+      }
+      steps {
+        container('maven') {
+        sh 'make validate'
+          dir ("./charts/$APP_NAME") {
+            sh 'make install'
+          }
+          print "Preview environment detais:"
+          print "HELM_RELEASE_NAME=${HELM_RELEASE_NAME}"
+          print "GATEWAY_HOST=${GATEWAY_HOST}"
+          print "SSO_HOST=${SSO_HOST}"
 
-    }
-    stages {
-      stage('Create Preview Environment') {
-        when {
-          branch 'feature-*'
+          input "Click Abort to delete preview environment: ${HELM_RELEASE_NAME}"
         }
-        environment {
-          HELM_RELEASE_NAME = "$BRANCH_NAME".toLowerCase()
-          PREVIEW_NAMESPACE = "$BRANCH_NAME".toLowerCase()
-          GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-          SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-        }
-        steps {
-          container('maven') {
-          sh 'make validate'
-           dir ("./charts/$APP_NAME") {
-              sh 'make install'
-            }
+      }
+      aborted {
+        container('maven') {
+          dir("./charts/$APP_NAME") {
+            sh "make delete"
+            sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
+          }
+        }          
+      }        
+    }
+    stage('CI Build and push snapshot') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+        SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+      }
+      steps {
+        container('maven') {
+        sh 'make validate'
+          dir ("./charts/$APP_NAME") {
+            // sh 'make build'
+            sh 'make install'
+          }
 
-            input "Wait"
+          dir("./activiti-cloud-acceptance-scenarios") {
+            git 'https://github.com/Activiti/activiti-cloud-acceptance-scenarios.git'
+            sh 'sleep 30'
+            sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests,modeling-acceptance-tests' clean verify"
           }
         }
       }
-      stage('CI Build and push snapshot') {
-        when {
-          branch 'PR-*'
-        }
-        environment {
-         GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-         SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-        }
-        steps {
-          container('maven') {
-          sh 'make validate'
-           dir ("./charts/$APP_NAME") {
-	           // sh 'make build'
-              sh 'make install'
-            }
-
-            dir("./activiti-cloud-acceptance-scenarios") {
-              git 'https://github.com/Activiti/activiti-cloud-acceptance-scenarios.git'
-              sh 'sleep 30'
-              sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests,modeling-acceptance-tests' clean verify"
-
-            }
-          }
-        }
-      }
-      stage('Build Release') {
-        when {
-          branch 'master'
-        }
-	environment {
-         GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-         SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
-        }      
-        steps {
-          container('maven') {
-            // ensure we're not on a detached head
-            sh "git checkout master"
-            sh "git config --global credential.helper store"
-
-            sh "jx step git credentials"
-            // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-        //RUNTIME bundle tests
-            dir ("./charts/$APP_NAME") {
-	           // sh 'make build'
-	      retry(5) {	    
-                sh 'make install'
-	      }
-            }
-	    //run RB and modeling tests
-            dir("./activiti-cloud-acceptance-scenarios") {
-              git 'https://github.com/Activiti/activiti-cloud-acceptance-scenarios.git'
-              sh 'sleep 30'
-              sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests,modeling-acceptance-tests' clean verify"
-             // sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests' clean verify"
-	    }	  
-	    //end run RB and modeling tests
-            //dir ("./charts/$APP_NAME") {
-            //   sh 'make delete'
-            //}
-            dir ("./charts/$APP_NAME") {
-           
-
-	      retry(5) {
-                sh 'make tag'
-              }
-            sh 'make release'
-	    retry(5) {
-                sh 'make github'
-             }            
-             retry(5) {  
-               sh 'make updatebot/push-version'
-	     }
-	    }
-          }
-        }
-      }
-
-       stage('Promote to Environments') {
-         when {
-            branch 'master'
-         }
-         steps {
-           container('maven') {
-             dir ("./charts/$APP_NAME") {
-               sh 'jx step changelog --version v\$(cat ../../VERSION)'
-	       retry(5) {	
-	         sh 'jx promote -b --all-auto --helm-repo-url=$GITHUB_HELM_REPO_URL --timeout 1h --version \$(cat ../../VERSION) --no-wait'
-	       }	      
-             }
-           }
-         }
-       }
-    }
-   post {
+      post {
         always {
           container('maven') {
             dir("./charts/$APP_NAME") {
-               sh "make delete"
+              sh "make delete"
             }
             sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
           }
-          cleanWs()
         }
-   }
+      }
+    }
+    stage('Build Release') {
+      when {
+        branch 'master'
+      }
+      environment {
+        GATEWAY_HOST = "gateway.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+        SSO_HOST = "identity.$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN"
+      }      
+      steps {
+        container('maven') {
+          // ensure we're not on a detached head
+          sh "git checkout master"
+          sh "git config --global credential.helper store"
+
+          sh "jx step git credentials"
+          // so we can retrieve the version in later steps
+          sh "echo \$(jx-release-version) > VERSION"
+          //RUNTIME bundle tests
+          dir ("./charts/$APP_NAME") {
+          // sh 'make build'
+          retry(5) {	    
+            sh 'make install'
+            }
+          }
+          //run RB and modeling tests
+          dir("./activiti-cloud-acceptance-scenarios") {
+            git 'https://github.com/Activiti/activiti-cloud-acceptance-scenarios.git'
+            sh 'sleep 30'
+            sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests,modeling-acceptance-tests' clean verify"
+            // sh "mvn clean install -DskipTests && mvn -pl 'runtime-acceptance-tests' clean verify"
+          }
+          //end run RB and modeling tests
+          //dir ("./charts/$APP_NAME") {
+          //   sh 'make delete'
+          //}
+          dir ("./charts/$APP_NAME") {
+            retry(5) {
+              sh 'make tag'
+            }
+            sh 'make release'
+            retry(5) {
+              sh 'make github'
+            }            
+            retry(5) {  
+              sh 'make updatebot/push-version'
+            }
+          }
+        }
+      }
+      post {
+        always {
+          container('maven') {
+            dir("./charts/$APP_NAME") {
+              sh "make delete"
+            }
+            sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
+          }
+        }
+      }
+    }
+
+    stage('Promote to Environments') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          dir ("./charts/$APP_NAME") {
+            sh 'jx step changelog --version v\$(cat ../../VERSION)'
+            retry(5) {	
+              sh 'jx promote -b --all-auto --helm-repo-url=$GITHUB_HELM_REPO_URL --timeout 1h --version \$(cat ../../VERSION) --no-wait'
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      cleanWs()
+    }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
             sh 'make install'
           }
           print "Preview environment detais:"
+          print "REALM=${REALM}"
           print "HELM_RELEASE_NAME=${HELM_RELEASE_NAME}"
           print "GATEWAY_HOST=${GATEWAY_HOST}"
           print "SSO_HOST=${SSO_HOST}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,12 +47,7 @@ pipeline {
       }
       post{ 
         aborted {
-          container('maven') {
-            dir("./charts/$APP_NAME") {
-              sh "make delete"
-              sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
-            }
-          }
+          delete_deployment()
         }
       }
     }
@@ -81,12 +76,7 @@ pipeline {
       }
       post {
         always {
-          container('maven') {
-            dir("./charts/$APP_NAME") {
-              sh "make delete"
-            }
-            sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
-          }
+          delete_deployment()
         }
       }
     }
@@ -141,12 +131,7 @@ pipeline {
       }
       post {
         always {
-          container('maven') {
-            dir("./charts/$APP_NAME") {
-              sh "make delete"
-            }
-            sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
-          }
+          delete_deployment()
         }
       }
     }
@@ -170,6 +155,14 @@ pipeline {
   post {
     always {
       cleanWs()
+    }
+  }
+  def delete_deployment() {
+    container('maven') {
+      dir("./charts/$APP_NAME") {
+        sh "make delete"
+      }
+      sh "kubectl delete namespace $PREVIEW_NAMESPACE" 
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,8 @@ clean:
 linux:
 	echo "do nothing"
 
+preview:
+	git checkout -b feature-${PREVIEW}
+	git push -u origin feature-${PREVIEW}
+
 .PHONY: release clean

--- a/charts/activiti-cloud-full-example/Makefile
+++ b/charts/activiti-cloud-full-example/Makefile
@@ -22,8 +22,12 @@ build: clean
 	helm lint
 
 install: clean build
-	sed -i -e "s/jx-staging/${PREVIEW_NAMESPACE}/g" values.yaml
-	helm install . --set global.gateway.domain=${GLOBAL_GATEWAY_DOMAIN} --name ${HELM_RELEASE_NAME} --namespace ${PREVIEW_NAMESPACE} --debug --wait 
+	helm upgrade ${HELM_RELEASE_NAME} . \
+		--install \
+		--set global.gateway.domain=${GLOBAL_GATEWAY_DOMAIN} \
+		--namespace ${PREVIEW_NAMESPACE} \
+		--debug \
+		--wait 
 
 upgrade: clean build
 	helm upgrade ${HELM_RELEASE_NAME} .


### PR DESCRIPTION
This PR adds stage to Jenkins triggered on `feature-*` branch pattern that installs Helm chart into preview namespace for development and testing using isolated versioned deployments, i.e.

```
git clone https://github.com/Activiti/activiti-cloud-full-chart.git && cd cd activiti-cloud-full-chart
git checkout -b feature-awesome
git push -u origin feature-awesome
```

or using `make`, i.e.

```
git clone https://github.com/Activiti/activiti-cloud-full-chart.git && cd cd activiti-cloud-full-chart
git checkout -b <base-branch or tag>
make preview PREVIEW=igdianov
```
