### PR TITLE
fix(GH-3734): add destinations override example values

### DIFF
--- a/charts/activiti-cloud-full-example/default-destinations-values.yaml
+++ b/charts/activiti-cloud-full-example/default-destinations-values.yaml
@@ -2,7 +2,7 @@ global:
   messaging:
     destinationPrefix: ""
     destinationSeparator: _
-    destinationOverrideEnabled: false
+    destinationTransformersEnabled: false
     destinationIllegalCharsRegex: "[\\t\\s*#:]"
     destinationIllegalCharsReplacement: "-"
     destinations: {}

--- a/charts/activiti-cloud-full-example/override-destinations-values.yaml
+++ b/charts/activiti-cloud-full-example/override-destinations-values.yaml
@@ -2,7 +2,7 @@ global:
   messaging:
     destinationPrefix: "{{ .Release.Namespace }}"
     destinationSeparator: .
-    destinationOverrideEnabled: true
+    destinationTransformersEnabled: true
     destinationIllegalCharsRegex: "[\\t\\s*#:]"
     destinationIllegalCharsReplacement: "-"
     destinations:


### PR DESCRIPTION
This PR adds example values to override destinations on shared message broker, i.e.

```yaml

global:
  messaging:
    destinationPrefix: "{{ .Release.Namespace }}"
    destinationSeparator: .
    destinationOverrideEnabled: true
    destinationIllegalCharsRegex: "[\\t\\s*#:]"
    destinationIllegalCharsReplacement: "-"
    destinations:
      engineEvents:
        name: engine-events
      signalEvent:
        name: signal-events
      commandConsumer:
        name: command-consumer
      asyncExecutorJobs:
        name: async-executor-jobs
      messageEvents:
        name: message-events
      commandResults:
        name: command-results
      integrationResult:
        name: integration-result
      integrationError:
        name: integration-error
```

Part of Activiti/Activiti#3734