### PR TITLE
fix: update base probe path with liveness and readiness paths

### DIFF
--- a/charts/activiti-cloud-full-example/README.md
+++ b/charts/activiti-cloud-full-example/README.md
@@ -38,9 +38,10 @@ Kubernetes: `>=1.15.0-0`
 | activiti-cloud-connector.ingress.annotations."nginx.ingress.kubernetes.io/enable-cors" | string | `"true"` |  |
 | activiti-cloud-connector.ingress.enabled | bool | `false` |  |
 | activiti-cloud-connector.ingress.path | string | `"/example-cloud-connector"` |  |
+| activiti-cloud-connector.livenessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/liveness"` |  |
 | activiti-cloud-connector.messaging.enabled | bool | `true` |  |
 | activiti-cloud-connector.nameOverride | string | `"activiti-cloud-connector"` |  |
-| activiti-cloud-connector.probePath | string | `"{{ tpl .Values.ingress.path . }}/actuator/health"` |  |
+| activiti-cloud-connector.readinessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/readiness"` |  |
 | activiti-cloud-connector.resources.limits.cpu | string | `"1"` |  |
 | activiti-cloud-connector.resources.limits.memory | string | `"1024Mi"` |  |
 | activiti-cloud-connector.resources.requests.cpu | string | `"150m"` |  |
@@ -248,9 +249,10 @@ Kubernetes: `>=1.15.0-0`
 | activiti-cloud-modeling.ingress.annotations."nginx.ingress.kubernetes.io/enable-cors" | string | `"true"` |  |
 | activiti-cloud-modeling.ingress.path | string | `"/modeling-service"` |  |
 | activiti-cloud-modeling.liquibase.enabled | bool | `true` |  |
+| activiti-cloud-modeling.livenessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/liveness"` |  |
 | activiti-cloud-modeling.nameOverride | string | `"activiti-cloud-modeling"` |  |
 | activiti-cloud-modeling.postgresql.enabled | bool | `true` |  |
-| activiti-cloud-modeling.probePath | string | `"{{ tpl .Values.ingress.path . }}/actuator/health"` |  |
+| activiti-cloud-modeling.readinessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/readiness"` |  |
 | activiti-cloud-modeling.resources.limits.cpu | string | `"1"` |  |
 | activiti-cloud-modeling.resources.limits.memory | string | `"1024Mi"` |  |
 | activiti-cloud-modeling.resources.requests.cpu | string | `"400m"` |  |
@@ -276,11 +278,12 @@ Kubernetes: `>=1.15.0-0`
 | activiti-cloud-query.javaOpts.xms | string | `"512m"` |  |
 | activiti-cloud-query.javaOpts.xmx | string | `"2048m"` |  |
 | activiti-cloud-query.liquibase.enabled | bool | `true` |  |
+| activiti-cloud-query.livenessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/liveness"` |  |
 | activiti-cloud-query.messaging.enabled | bool | `true` |  |
 | activiti-cloud-query.messaging.role | string | `"consumer"` |  |
 | activiti-cloud-query.nameOverride | string | `"activiti-cloud-query"` |  |
 | activiti-cloud-query.postgresql.enabled | bool | `true` |  |
-| activiti-cloud-query.probePath | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health"` |  |
+| activiti-cloud-query.readinessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/readiness"` |  |
 | activiti-cloud-query.resources.limits.cpu | string | `"1.5"` |  |
 | activiti-cloud-query.resources.limits.memory | string | `"2048Mi"` |  |
 | activiti-cloud-query.resources.requests.cpu | string | `"200m"` |  |
@@ -355,11 +358,12 @@ Kubernetes: `>=1.15.0-0`
 | runtime-bundle.ingress.path | string | `"/rb"` |  |
 | runtime-bundle.javaOpts.xms | string | `"512m"` |  |
 | runtime-bundle.javaOpts.xmx | string | `"2048m"` |  |
+| runtime-bundle.livenessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/liveness"` |  |
 | runtime-bundle.messaging.enabled | bool | `true` |  |
 | runtime-bundle.messaging.role | string | `"producer"` |  |
 | runtime-bundle.nameOverride | string | `"runtime-bundle"` |  |
 | runtime-bundle.postgresql.enabled | bool | `true` |  |
-| runtime-bundle.probePath | string | `"{{ tpl .Values.ingress.path . }}/actuator/health"` |  |
+| runtime-bundle.readinessProbe.path | string | `"{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/actuator/health/readiness"` |  |
 | runtime-bundle.resources.limits.cpu | string | `"2"` |  |
 | runtime-bundle.resources.limits.memory | string | `"2048Mi"` |  |
 | runtime-bundle.resources.requests.cpu | string | `"200m"` |  |

--- a/charts/activiti-cloud-full-example/values.yaml
+++ b/charts/activiti-cloud-full-example/values.yaml
@@ -380,7 +380,10 @@ activiti-cloud-modeling:
       nginx.ingress.kubernetes.io/cors-allow-headers: Authorization, Content-Type, Accept
   postgresql:
     enabled: true
-  probePath: '{{ tpl .Values.ingress.path . }}/actuator/health'
+  readinessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/readiness'
+  livenessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/liveness'
   resources:
     requests:
       cpu: 400m
@@ -477,7 +480,10 @@ runtime-bundle:
     requests:
       cpu: 200m
       memory: 512Mi
-  probePath: '{{ tpl .Values.ingress.path . }}/actuator/health'
+  readinessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/readiness'
+  livenessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/liveness'
   extraEnv: |-
     - name: SERVER_SERVLET_CONTEXTPATH
       value: "{{ tpl .Values.ingress.path . }}"
@@ -528,7 +534,10 @@ activiti-cloud-query:
     requests:
       cpu: 200m
       memory: 512Mi
-  probePath: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health'
+  readinessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/readiness'
+  livenessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/liveness'
   extraEnv: |-
     - name: GRAPHIQL_GRAPHQL_WEB_PATH
       value: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/notifications/graphql'
@@ -572,7 +581,10 @@ activiti-cloud-connector:
     requests:
       cpu: 150m
       memory: 256Mi
-  probePath: '{{ tpl .Values.ingress.path . }}/actuator/health'
+  readinessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/readiness'
+  livenessProbe:
+    path: '{{ tpl .Values.ingress.path . | trimSuffix "/" }}/actuator/health/liveness'
 ##
 ## Kafka chart configuration
 ##


### PR DESCRIPTION
This PR replaces base probe path with liveness and readiness specific probes

Depends on: https://github.com/Activiti/activiti-cloud-common-chart/pull/36

Part of https://github.com/Activiti/Activiti/issues/3747