### PR TITLE
fix: update default value for Open API server for audit and query

### DIFF
--- a/charts/activiti-cloud-full-example/README.md
+++ b/charts/activiti-cloud-full-example/README.md
@@ -260,7 +260,7 @@ Kubernetes: `>=1.15.0-0`
 | activiti-cloud-modeling.service.name | string | `"modeling"` |  |
 | activiti-cloud-query.db.ddlAuto | string | `"none"` | set to 'none' temporarily rather than default 'validate' that breaks |
 | activiti-cloud-query.enabled | bool | `true` |  |
-| activiti-cloud-query.extraEnv | string | `"- name: GRAPHIQL_GRAPHQL_WEB_PATH\n  value: '{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/notifications/graphql'\n- name: GRAPHIQL_GRAPHQL_WS_PATH\n  value: '{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/notifications/ws/graphql'\n- name: SERVER_SERVLET_CONTEXTPATH\n  value: \"{{ tpl .Values.ingress.path . }}\"\n- name: SERVER_USEFORWARDHEADERS\n  value: \"true\"\n- name: SERVER_TOMCAT_INTERNALPROXIES\n  value: \".*\""` |  |
+| activiti-cloud-query.extraEnv | string | `"- name: GRAPHIQL_GRAPHQL_WEB_PATH\n  value: '{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/notifications/graphql'\n- name: GRAPHIQL_GRAPHQL_WS_PATH\n  value: '{{ tpl .Values.ingress.path . | trimSuffix \"/\" }}/notifications/ws/graphql'\n- name: SERVER_SERVLET_CONTEXTPATH\n  value: \"{{ tpl .Values.ingress.path . }}\"\n- name: SERVER_USEFORWARDHEADERS\n  value: \"true\"\n- name: SERVER_TOMCAT_INTERNALPROXIES\n  value: \".*\"\n- name: ACTIVITI_CLOUD_SWAGGER_QUERYBASEPATH\n  value: \"/query\"\n- name: ACTIVITI_CLOUD_SWAGGER_AUDITBASEPATH\n  value: \"/audit\""` |  |
 | activiti-cloud-query.image.pullPolicy | string | `"Always"` |  |
 | activiti-cloud-query.image.repository | string | `"activiti/activiti-cloud-query"` |  |
 | activiti-cloud-query.image.tag | string | `"7.1.1099"` |  |

--- a/charts/activiti-cloud-full-example/values.yaml
+++ b/charts/activiti-cloud-full-example/values.yaml
@@ -549,6 +549,10 @@ activiti-cloud-query:
       value: "true"
     - name: SERVER_TOMCAT_INTERNALPROXIES
       value: ".*"
+    - name: ACTIVITI_CLOUD_SWAGGER_QUERYBASEPATH
+      value: "/query"
+    - name: ACTIVITI_CLOUD_SWAGGER_AUDITBASEPATH
+      value: "/audit"
 activiti-cloud-connector:
   enabled: true
   nameOverride: activiti-cloud-connector


### PR DESCRIPTION
Differently from runtime bundle and modeling service, the servlet context is not set with the service prefix, so it should be included in the server in the Open API to get the swagger UI working properly

Part of https://github.com/Activiti/Activiti/issues/3754