### PR TITLE
AAE-16060 Update helm-release-and-publish action to fix build ad rc and workflows concurrency errors

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -30,7 +30,7 @@ jobs:
 
       - id: helm-publish-chart
         name: Publish Helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.37.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@dev-igdianov-AAE-16060
         with:
           chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
           helm-charts-repo: ${{ env.HELM_REPO }}


### PR DESCRIPTION
Depends on https://github.com/Alfresco/alfresco-build-tools/pull/324