### PR TITLE
AAE-46386 Set DependaBot cooldown for all ecosystems as 3d

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     ignore:
       - dependency-name: "bridgecrewio/checkov-action"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]


### PR DESCRIPTION
Configure DependaBot cooldown period for all package ecosystems.

## Changes
- Added `cooldown` with `default-days: 3` as a sibling to `schedule` in `.github/dependabot.yml`

## Rationale
Setting a 3-day cooldown period helps prevent DependaBot from proposing dependencies which would be vectors for supply chain attacks as soon as they are released.
